### PR TITLE
Add crypto tracking to options tool

### DIFF
--- a/options_tool.py
+++ b/options_tool.py
@@ -1,0 +1,135 @@
+# Basic 0DTE Options Trading Tool (Tech Sector) with Free Options Chain Filtering
+# Requirements: yfinance, pandas, ta, schedule
+
+import yfinance as yf
+import pandas as pd
+import schedule
+import time
+from datetime import datetime
+
+# Crypto tickers for tracking price changes
+CRYPTO_TICKERS = ["BTC-USD", "ETH-USD"]
+
+# Define tech tickers
+TECH_TICKERS = ["AAPL", "MSFT", "NVDA", "AMD", "GOOG", "AMZN", "META", "TSLA"]
+
+# Parameters for signal detection
+RSI_PERIOD = 14
+RSI_OVERBOUGHT = 70
+RSI_OVERSOLD = 30
+BREAKOUT_THRESHOLD = 0.5  # % change in price to consider breakout
+
+# Options filtering thresholds
+MIN_VOLUME = 100           # minimum options volume
+MIN_OPEN_INTEREST = 100    # minimum open interest
+MAX_MONEYNESS = 0.1        # max moneyness (10%) for OTM selection
+MIN_IV = 0.5               # minimum implied volatility (50%)
+
+# Fetch 5-minute intraday data
+def fetch_intraday_data(ticker):
+    data = yf.download(ticker, period="1d", interval="5m", progress=False)
+    return data
+
+# Fetch options chain for expirations within 0-1 DTE
+def fetch_options_chain(ticker):
+    tk = yf.Ticker(ticker)
+    exps = tk.options
+    today = datetime.now().date()
+    valid_exps = [exp for exp in exps if abs((pd.to_datetime(exp).date() - today).days) <= 1]
+    chains = []
+    for exp in valid_exps:
+        opt = tk.option_chain(exp)
+        calls = opt.calls.copy(); calls["type"] = "call"
+        puts  = opt.puts.copy();  puts["type"]  = "put"
+        df = pd.concat([calls, puts], ignore_index=True)
+        df["expirationDate"] = pd.to_datetime(exp)
+        chains.append(df)
+    if chains:
+        return pd.concat(chains, ignore_index=True)
+    return pd.DataFrame()
+
+
+# --- Crypto Tracking -------------------------------------------------------
+def track_crypto_prices():
+    """Fetch daily price change for BTC and ETH and print the results."""
+    print("Crypto price changes (daily):")
+    for symbol in CRYPTO_TICKERS:
+        df = yf.download(symbol, period="1d", interval="5m", progress=False)
+        if df.empty:
+            print(f"    No data for {symbol}")
+            continue
+        open_price = df["Close"].iloc[0]
+        last_price = df["Close"].iloc[-1]
+        pct_change = (last_price - open_price) / open_price * 100
+        print(f"    {symbol}: {last_price:.2f} ({pct_change:+.2f}%)")
+
+# Filter for liquid, OTM options near ATM price
+def filter_options(chain_df, price):
+    if chain_df.empty:
+        return chain_df
+    chain_df = chain_df.copy()
+    # Moneyness as absolute difference from spot
+    chain_df["moneyness"] = abs(chain_df.strike - price) / price
+    filtered = chain_df[
+        (chain_df.volume       >= MIN_VOLUME) &
+        (chain_df.openInterest >= MIN_OPEN_INTEREST) &
+        (chain_df.impliedVolatility >= MIN_IV) &
+        (chain_df.moneyness    <= MAX_MONEYNESS)
+    ]
+    return filtered
+
+# Detect RSI & breakout signals
+def detect_signals(df):
+    import ta
+    df['rsi']     = ta.momentum.RSIIndicator(df['Close'], window=RSI_PERIOD).rsi()
+    df['returns'] = df['Close'].pct_change() * 100
+    latest = df.iloc[-1]
+    return {
+        'price'          : latest['Close'],
+        'rsi_value'      : latest['rsi'],
+        'return_percent' : latest['returns'],
+        'rsi_signal'     : 'buy' if latest['rsi'] < RSI_OVERSOLD else 'sell' if latest['rsi'] > RSI_OVERBOUGHT else 'neutral',
+        'breakout_signal': 'breakout' if abs(latest['returns']) > BREAKOUT_THRESHOLD else 'none'
+    }
+
+# Print alerts
+def alert_user(ticker, signals, opts_df):
+    print(f"[{datetime.now()}] {ticker}: Price={signals['price']:.2f}, RSI={signals['rsi_value']:.2f}, Return={signals['return_percent']:.2f}%")
+    print(f"    Signals: {signals['rsi_signal']}, Breakout: {signals['breakout_signal']}")
+    if not opts_df.empty:
+        print("    Filtered 0-1 DTE Options:")
+        cols = ['contractSymbol','type','strike','expirationDate','lastPrice','bid','ask','volume','openInterest','impliedVolatility']
+        print(opts_df[cols].to_string(index=False))
+    else:
+        print("    No options match filter criteria.")
+
+# Full analysis per ticker
+def analyze_ticker(ticker):
+    try:
+        df = fetch_intraday_data(ticker)
+        if df.empty:
+            print(f"No data for {ticker}")
+            return
+        signals = detect_signals(df)
+        opts    = fetch_options_chain(ticker)
+        filtered_opts = filter_options(opts, signals['price'])
+        alert_user(ticker, signals, filtered_opts)
+    except Exception as e:
+        print(f"Error processing {ticker}: {e}")
+
+# Scheduler job
+def run_trading_scan():
+    print(f"\n=== Running 0-1 DTE scan at {datetime.now()} ===")
+    track_crypto_prices()
+    for ticker in TECH_TICKERS:
+        analyze_ticker(ticker)
+
+# Schedule every 15 minutes during market hours
+schedule.every(15).minutes.do(run_trading_scan)
+
+if __name__ == "__main__":
+    print("Starting 0-1 DTE Options Signal Tool...")
+    run_trading_scan()
+    while True:
+        schedule.run_pending()
+        time.sleep(1)


### PR DESCRIPTION
## Summary
- add crypto tickers constant
- add `track_crypto_prices` to report BTC and ETH movement
- call crypto tracking during scheduled scan

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861b278fb54832490787ddd54c0f4b4